### PR TITLE
Add view permission on openshift-pipelines for vdm and chmou

### DIFF
--- a/cluster_setup/pipelines_permissions.yaml
+++ b/cluster_setup/pipelines_permissions.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: tekton-pipelines-view-permission
+  namespace: openshift-pipelines
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: view
+subjects:
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: vdemeester
+- apiGroup: rbac.authorization.k8s.io
+  kind: User
+  name: chmouel


### PR DESCRIPTION
Previous PR on https://github.com/openshift-knative/cluster-devint/pull/17/commits/687ac2072affbea29861678ae0e89e30b16448dc was failing because it was trying to do it on `tekton-pipelines` but devint install the operator and it's located in `openshift-pipelines`

cc @vdemeester @bbrowning 